### PR TITLE
Fix token address format

### DIFF
--- a/providers/schema.graphql
+++ b/providers/schema.graphql
@@ -32,8 +32,6 @@ type Endpoint @entity {
 
 type User @entity {
   id: ID!  # user's address
-  # endpoints: [Endpoint!]  # endpoints they're bonded to
-  owns: [Endpoint!]  # endpoints they own
   userBound: [Bond!] @derivedFrom(field: "user")  # info on each bonded endpoint
 }
 

--- a/providers/src/bond_events.ts
+++ b/providers/src/bond_events.ts
@@ -51,12 +51,6 @@ export function handleBound(event: Bound): void {
   //   // then add it to the array of the user-owned endpoints
   // }
 
-  if ((event.params.holder.toHex() == endpoint.broker) && endpoint.broker != null) {
-    if (!user.owns.includes(endpoint.id)) {
-      user.owns.push(endpoint.id)
-    }
-  }
-
   // updates the number of user-bound dots
   let boundedResult = bondage.try_getBoundDots(event.params.holder, event.params.oracle, event.params.endpoint)
   if (boundedResult.reverted) {

--- a/providers/src/reg_events.ts
+++ b/providers/src/reg_events.ts
@@ -66,7 +66,7 @@ export function handleNewCurve(event: NewCurve): void {
     endpoint.tokenAdd = null
     log.debug("Issue with getting token address for {}", [endpoint.endpointStr])
   } else {
-    endpoint.tokenAdd = tokenAddResult.value.toString()
+    endpoint.tokenAdd = tokenAddResult.value.toHex()
     if (endpoint.tokenAdd != null) {
       // if the endpoint is a token then get more metadata on it...
       endpoint.isToken = true


### PR DESCRIPTION
## Summary
Token addresses are now being formatted as hex instead of utf8 strings

## Implementation
`endpoint.tokenAdd = tokenAddResult.value.toString()` -> `endpoint.tokenAdd = tokenAddResult.value.toHex()`

## Files
`providers/src/reg_events.ts`

## Visual Preview
![](https://i.ibb.co/cyRWYBq/image.png)